### PR TITLE
fix: develop 태그 이미지 빌드 추가

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,4 +33,6 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ghcr.io/sw-campus/sw-campus-ai:${{ github.sha }}
+          tags: |
+            ghcr.io/sw-campus/sw-campus-ai:${{ github.sha }}
+            ghcr.io/sw-campus/sw-campus-ai:develop


### PR DESCRIPTION
- develop 브랜치 빌드 시 develop 태그로도 이미지 푸시
- 매니페스트 워크플로우의 develop 태그 폴백 지원