### PR TITLE
feat: add release image build workflow for tag-based releases

### DIFF
--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -1,0 +1,35 @@
+name: Build Release Image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push Image
+        run: |
+          IMAGE=ghcr.io/sw-campus/sw-campus-ai
+          TAG=${{ github.ref_name }}
+          echo "Building RELEASE image with tag $TAG"
+          docker build -t $IMAGE:$TAG .
+          docker push $IMAGE:$TAG
+


### PR DESCRIPTION
변경 사항:
- v* 태그가 푸시되면 자동으로 이미지 빌드 및 푸시
- 태그 이름을 그대로 이미지 태그로 사용 (예: v1.0.0)
- release 전용 워크플로우로 분리

사용법:
git tag v1.0.0
git push origin v1.0.0

변경 파일:
- .github/workflows/build-release-image.yml